### PR TITLE
Resolves #47 - PEP8 lint

### DIFF
--- a/.lesshintrc
+++ b/.lesshintrc
@@ -1,0 +1,5 @@
+{
+  "propertyOrdering": {
+      "enabled": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@
         - typescript@1.8.10
         args:
         - --fix
+-   repo: git://github.com/kosarko/pre-commit-lesshint/
+    sha: v0.0.2
+    hooks:
+    -   id: lesshint
+        additional_dependencies:
+        - lesshint@4.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,3 @@
         args:
         - -i
         - --max-line-length=100
-
--   repo: git://github.com/pre-commit/mirrors-pylint
-    sha: 'v1.7.2'
-    hooks:
-    -   id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+-   repo: git://github.com/pre-commit/mirrors-autopep8
+    sha: v1.3.2
+    hooks:
+    -   id: autopep8
+        args:
+        - -i
+        - --max-line-length=100
+
+-   repo: git://github.com/pre-commit/mirrors-pylint
+    sha: 'v1.7.2'
+    hooks:
+    -   id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,12 @@
         args:
         - -i
         - --max-line-length=100
+-   repo: git://github.com/awebdeveloper/pre-commit-tslint/
+    sha: 0.0.2
+    hooks:
+    -   id: tslint
+        additional_dependencies:
+        - tslint@5.0.0
+        - typescript@1.8.10
+        args:
+        - --fix

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pre-commit

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,23 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "eofline": false,
+        "max-line-length": [true, 100],
+        "member-access": false,
+        "array-type": [false],
+        "ordered-imports": [false],
+        "object-literal-sort-keys": false,
+        "no-var-requires": false,
+        "interface-name": [
+            false
+        ],
+	"quotemark": [true, "single"],
+	"prefer-const": false
+    },
+    "rulesDirectory": [],
+    "exclude": ["**/node_modules/**/*"]
+}


### PR DESCRIPTION
Add configuration for pre-commit (http://pre-commit.com/) hooks manager.
Currently should run autopep8 (modify commited files in place to conform to pep8) and pylint (for other suggestions than codestyle).
See .pre-commit-config.yaml for the configuration.
Enable with first installing pre-commit `pip install pre-commit` (or `pip install -r requirements-dev.txt`) and follow with adding the git pre-commit hook `pre-commit install`.
Resolves #47 