### PR TITLE
Resolves #49 - Unit tests & CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
+sudo: required
 language: python
 python:
-  - "2.6"
   - "2.7"
+env:
+  - PYTHONPATH=./tests/mocks
+before_install:
+  - sudo apt-get install libxml2-dev libxslt-dev python-dev
+install:
+  - pip install -r requirements.txt
+script:
+  - python tests/runtests.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 env:
   - PYTHONPATH=./tests/mocks
 before_install:
-  - sudo apt-get install libxml2-dev libxslt-dev python-dev
+  - sudo apt-get install libxml2-dev libxslt-dev python-dev python-pyicu
 install:
-  - pip install -r requirements.txt
+  - xargs -a requirements.txt -n 1 pip install
 script:
   - python tests/runtests.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_install:
   - sudo apt-get install libxml2-dev libxslt-dev python-dev python-pyicu
 install:
-  - xargs -a requirements.txt -n 1 pip install
+  - pip install -r dev-requirements.txt
 script:
   - python tests/runtests.py
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+Cheetah >= 2.4.4
+Werkzeug >= 0.11
+lxml >= 3.4
+Markdown >= 2.5
+openpyxl >= 2.1
+redis >= 2.10
+

--- a/tests/mocks/manatee.py
+++ b/tests/mocks/manatee.py
@@ -1,0 +1,5 @@
+print('Fake manatee module loaded')
+
+
+def version():
+    return 'Fake-manatee'


### PR DESCRIPTION
Resolves #49 - Unit tests & CI. Cherry-picked `.travis.yml` from upstream master. Esentially this runs tests as defined in `tests/runtests.py` (sofar no autodiscovery) without manatee and "in memory database" (very simple mock classes used to get it up and running).