### PR TITLE
Resolves #68 - Simple endpoint providing information

### DIFF
--- a/build-scripts/configs/test_config.xml
+++ b/build-scripts/configs/test_config.xml
@@ -185,6 +185,9 @@
             <template_cs extension-by="lindat">/opt/kontext/installation/public/files/themes/lindat/lindat-common/cs/footer.htm</template_cs>
             <template_en extension-by="lindat">/opt/kontext/installation/public/files/themes/lindat/lindat-common/en/footer.htm</template_en>
         </footer_bar>
+        <status>
+            <module>lindat_status</module>
+        </status>
     </plugins>
 </kontext>
 

--- a/lib/actions/custom.py
+++ b/lib/actions/custom.py
@@ -1,0 +1,19 @@
+from controller import exposed
+from kontext import Kontext
+
+
+class Custom(Kontext):
+    def __init__(self, request, ui_lang):
+        """
+        arguments:
+        request -- Werkzeug's request object
+        ui_lang -- a language code in which current action's result will be presented
+        """
+        super(Custom, self).__init__(request=request, ui_lang=ui_lang)
+
+    def get_mapping_url_prefix(self):
+        return '/custom/'
+
+    @exposed(return_type='json')
+    def my_test(self, request):
+        return 'This works'

--- a/lib/initializer.py
+++ b/lib/initializer.py
@@ -90,3 +90,4 @@ def setup_plugins():
     init_plugin('syntax_viewer', optional=True)
     init_plugin('subcmixer', optional=True)
 
+    init_plugin('status', optional=True)

--- a/lib/plugins/lindat_status/__init__.py
+++ b/lib/plugins/lindat_status/__init__.py
@@ -1,0 +1,23 @@
+from controller import exposed
+import actions.custom
+
+
+def create_lindat_status_action(commit):
+    @exposed(return_type='json')
+    def lindat_status(controller, request):
+        return {'commit': commit}
+
+    return lindat_status
+
+
+class LindatStatus(object):
+    def __init__(self, commit):
+        self._commit = commit
+
+    def export_actions(self):
+        return {actions.custom.Custom: [create_lindat_status_action(self._commit)]}
+
+def create_instance(settings):
+    import subprocess
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip()
+    return LindatStatus(commit)

--- a/public/app.py
+++ b/public/app.py
@@ -140,6 +140,8 @@ class WsgiApp(object):
             from actions.admin import Admin as ControllerClass
         elif path_info.startswith('/corpora'):
             from actions.corpora import Corpora as ControllerClass
+        elif path_info.startswith('/custom'):
+            from actions.custom import Custom as ControllerClass
         else:
             from actions.concordance import Actions as ControllerClass
         return ControllerClass


### PR DESCRIPTION
Resolves #68 - Simple endpoint providing information. Adding `/custom/` controller and a status plugin
This is done to implement `/custom/lindat_status` endpoint that currently returns the current git commit sha1.

Originally the plugin should have added new action under the root `/`; that didn't work. It adds the action under newly created `/custom/` controller instead. The functionality in the plugin could easily be part of the controller.