### PR TITLE
Resolves #123 - Setting correct url if behind a proxy with specific "HTTP_X_FORWARDED_FOR

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -464,7 +464,8 @@ class Controller(object):
             protocol = self.environ['HTTP_X_FORWARDED_PROTOCOL']
         else:
             protocol = self.environ['wsgi.url_scheme']
-        url_items = ('%s://%s' % (protocol, self.environ.get('HTTP_HOST')),
+        url_items = ('%s://%s' % (protocol, settings.get_str('global', 'http_host',
+                                                             self.environ.get('HTTP_HOST'))),
                      settings.get_str('global', 'action_path_prefix', ''),
                      action_module_path)
         return '/'.join(filter(lambda x: bool(x), map(lambda x: x.strip('/'), url_items))) + '/'


### PR DESCRIPTION
Resolves #123 - Setting correct url if behind a proxy with specific "HTTP_X_FORWARDED_FOR. You can specify `http_host` element in the global part of `config.xml`.

@vidiecan What about cookies? should we care also about specifying the cookie domain, or are there no issues with ProxyPassReverseCookieDomain?