### PR TITLE
Resolves #83 - Recent queries

### DIFF
--- a/lib/actions/user.py
+++ b/lib/actions/user.py
@@ -127,7 +127,8 @@ class User(Kontext):
         self.disabled_menu_items = (MainMenu.VIEW, MainMenu.SAVE,
                                     MainMenu.CONCORDANCE, MainMenu.FILTER, MainMenu.FREQUENCY,
                                     MainMenu.COLLOCATIONS)
-        num_records = int(settings.get('plugins', 'query_storage').get('page_num_records', 0))
+        num_records = int(settings.get('plugins', 'query_storage').get('default:page_num_records',
+                                                                       0))
 
         if not offset:
             offset = 0


### PR DESCRIPTION
Resolves #83 - Recent queries; the issue was that the `num_records` is passed to `self._load_query_history` as limit; so when you don't find `page_num_records` in the configs (which you won't if you have it as an extension) you are effectively passing 0 as the limit, hence no row is fetched.

@tomachalek is there a reason why page_num_records should be a default extension;
```
<page_num_records extension-by="default">10</page_num_records>
```
if there is then this fix should be applied otherwise let's just update the config