### PR TITLE
corpus access forbidden fallback - a solution

### DIFF
--- a/lib/controller/kontext.py
+++ b/lib/controller/kontext.py
@@ -664,12 +664,7 @@ class Kontext(Controller):
                     self.redirect(self.create_url('first_form', dict(corpname=corpname)))
                 elif not has_access:
                     path = ['message']
-                    if corpname:
-                        self.add_system_message('error', _(
-                            'Corpus "{0}" not available').format(corpname))
-                    else:
-                        self.add_system_message('error', _('No corpus selected'))
-                    self.set_not_found()
+                    auth.on_forbidden_corpus(self._plugin_api, corpname, variant)
             else:
                 corpname = ''
                 variant = ''

--- a/lib/controller/plg.py
+++ b/lib/controller/plg.py
@@ -79,6 +79,12 @@ class PluginApi(object):
     def redirect(self, url, code=303):
         return self._controller.redirect(url, code=code)
 
+    def set_not_found(self):
+        return self._controller.set_not_found()
+
+    def add_system_message(self, msg_type, text):
+        self._controller.add_system_message(msg_type, text)
+
     @property
     def text_types(self):
         ans = {}

--- a/lib/plugins/abstract/auth.py
+++ b/lib/plugins/abstract/auth.py
@@ -66,6 +66,21 @@ class AbstractAuth(object):
         """
         raise NotImplementedError()
 
+    def on_forbidden_corpus(self, plugin_api, corpname, corp_variant):
+        """
+        Optional method run in case KonText finds out that user
+        does not have access rights to a corpus specified by 'corpname'.
+        There are two main action types you can perform here:
+        1) Redirect to a different page or set 'not found'.
+        2) Set some system message user can read.
+        """
+        if corpname:
+            plugin_api.add_system_message('error', _(
+                'Corpus "{0}" not available').format(corpname))
+        else:
+            plugin_api.add_system_message('error', _('No corpus selected'))
+        plugin_api.set_not_found()
+
     def get_user_info(self, user_id):
         """
         Return a dictionary containing all the data about a user.


### PR DESCRIPTION
I've added a new function on_forbidden_corpus which allows
a custom auth implementation to react to a situation when
user cannot access a corpus. The reaction can be: redirect,
404 not found, system message.